### PR TITLE
Исправляем в админке клик по карте

### DIFF
--- a/core/components/yandexmaps/tv/input/tpl/tv.yandexMaps.input.tpl
+++ b/core/components/yandexmaps/tv/input/tpl/tv.yandexMaps.input.tpl
@@ -106,10 +106,10 @@ Ext.onReady(function(){
 
 <script type="text/javascript">
 // Функция подгрузки подсказок
-function ymOnLoad (ymaps)
-{
-	window.suggestView = new ymaps.SuggestView('suggest', {literal}{'results':'9'}{/literal});
-}
+//function ymOnLoad (ymaps)
+//{
+//	window.suggestView = new ymaps.SuggestView('suggest', {literal}{'results':'9'}{/literal});
+//}
 
 // Функция замены строки
 function str_replace (needle, replacement, haystack)
@@ -177,6 +177,8 @@ Ext.onReady(function(){
 		
 		
 		// >> Слушаем клик на подсказках в поиске
+		var suggestView = new ymaps.SuggestView('suggest', {'results': '9'});
+		
 		suggestView.events.add('select', function (e) {
 			var address = e.get('item').value;
 			//console.log( address );


### PR DESCRIPTION
Маленькое исправление для админки.
С ним начинает работать клик по карте с установкой координат в ручную. Т.к. из коробки работал только поиск по адресу. И если сместить точку, то координаты не пересчитывались. 

С этим исправлением в админке все начинает работать корректно.